### PR TITLE
Handle empty string responses

### DIFF
--- a/src/SalesforceApi.php
+++ b/src/SalesforceApi.php
@@ -201,6 +201,10 @@ class SalesforceApi
      */
     protected function unpackResponseIfNeeded(Response $response): mixed
     {
+        if ($response->successful() && empty($response->body())) {
+            return [];
+        }
+
         $inlineData = $response->json();
 
         if (isset($inlineData['records']) && $this->recordsOnly) {


### PR DESCRIPTION
If the salesforce API returns a 200 or 204 response but the body is an empty string `""`, the json_decode method throws an exception. 
This update allows an empty string response to not throw an exception but return an [].
Not sure if we want to return more than an empty array. 